### PR TITLE
fixes hitobito/hitobito#707

### DIFF
--- a/app/views/song_counts/_form.html.haml
+++ b/app/views/song_counts/_form.html.haml
@@ -1,7 +1,7 @@
 .row
-  .col.no-wrap.count
+  .col.no-wrap.count{style: "z-index: 10"}
     = song_counts_update_button(:dec)
-    = f.input_field :count, min: 0, size: 2, max: 30, 
+    = f.input_field :count, min: 0, size: 2, max: 30,
                     class: 'auto-size text-right', 
                     style: 'width: unset', 
                     autofocus: (f.object.id == params[:focus].to_i)

--- a/app/views/songs/create.js.haml
+++ b/app/views/songs/create.js.haml
@@ -3,6 +3,6 @@
   $(".song-counts form.new_song_count").submit();
   $("#new_song")[0].reset();
   $('.song-counts #new_song').hide();
-  window.App.SongCounts.add('#{j(entry.to_json.html_safe)}')
+  window.App.SongCounts.add('#{j(entry.attributes.merge(label: entry.decorate.full_label).to_json.html_safe)}')
 
 $('#flash').html("#{j(render(partial: "layouts/flash", collection: [:notice, :alert], as: :level))}");


### PR DESCRIPTION
`create.js` was not providing label attribute needed to render the element, fixes hitobito/hitobito#707, also resolves an issue where click area is hidden behind content.