### PR TITLE
Update People Development Seeds with myself as dev

### DIFF
--- a/db/seeds/development/1_people.rb
+++ b/db/seeds/development/1_people.rb
@@ -47,7 +47,9 @@ admins = {
   'Martin Eckenfels'   => 'm.eckenfels@bluewin.ch'
 }
 
-devs = {}
+devs = {
+  'Aleksandar Radunovic' => 'aleksandar.radunovic@consulteer.com'
+}
 
 puzzlers.each do |puz|
   devs[puz] = "#{puz.split.last.downcase}@puzzle.ch"


### PR DESCRIPTION
## Description ##
As agreed with @kronn, I'm supposed to add my info to the development seeds (devs list).

## What's changed? ##

- People seeds (`db/seeds/development/1_people.rb`) for development environment now contains me as a developer

## Screenshots ##

![Screenshot-1574157768](https://user-images.githubusercontent.com/7906832/69136856-ec6dc380-0abb-11ea-809a-9d4c94c69efa.png)
