### PR TITLE
EMF 2021: Add Festival event-type

### DIFF
--- a/app/abilities/sbv/group_ability.rb
+++ b/app/abilities/sbv/group_ability.rb
@@ -1,0 +1,9 @@
+module Sbv::GroupAbility
+  extend ActiveSupport::Concern
+
+  included do
+    on(Group) do
+      permission(:any).may(:'index_event/festivals').all
+    end
+  end
+end

--- a/app/helpers/sbv/sheet/group.rb
+++ b/app/helpers/sbv/sheet/group.rb
@@ -16,6 +16,6 @@ module Sbv::Sheet::Group
                                    (view.can?(:index_song_counts, group) ||
                                    view.can?(:manage_song_census, group))
                                end))
-
+    tabs.insert(5, Sheet::Tab.new('group.festival_tab', :festival_group_events_path))
   end
 end

--- a/app/helpers/sbv/sheet/group.rb
+++ b/app/helpers/sbv/sheet/group.rb
@@ -16,6 +16,13 @@ module Sbv::Sheet::Group
                                    (view.can?(:index_song_counts, group) ||
                                    view.can?(:manage_song_census, group))
                                end))
-    tabs.insert(5, Sheet::Tab.new('group.festival_tab', :festival_group_events_path))
+    tabs.insert(5,
+                Sheet::Tab.new('group.festival_tab', :festival_group_events_path,
+                                params: { returning: true },
+                                if: (lambda do |view, group|
+                                  group.event_types.include?(::Event::Festival) &&
+                                    view.can?(:'index_event/festivals', group)
+                                end)
+               ))
   end
 end

--- a/app/models/event/festival.rb
+++ b/app/models/event/festival.rb
@@ -1,0 +1,7 @@
+#  Copyright (c) 2012-2019, Schweizer Blasmusikverband. This file is part of
+#  hitobito_sbv and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sbv.
+
+class Event::Festival < Event
+end

--- a/app/models/group/root.rb
+++ b/app/models/group/root.rb
@@ -47,7 +47,7 @@ class Group::Root < ::Group
                            Group::RootEhrenmitglieder,
                            Group::RootVeteranen]
 
-  self.event_types = [Event, Event::Course]
+  self.event_types = [Event, Event::Course, Event::Festival]
 
   children Group::RootGeschaeftsstelle,
            Group::RootVorstand,

--- a/config/locales/views.sbv.de.yml
+++ b/config/locales/views.sbv.de.yml
@@ -7,6 +7,7 @@ de:
   global:
     last_change: "Letzte Änderung: %{date}"
   group:
+    festival_tab: Festival
     suisa_tab: SUISA
     merge:
       select:

--- a/config/locales/views.sbv.fr.yml
+++ b/config/locales/views.sbv.fr.yml
@@ -9,6 +9,7 @@ fr:
   global:
     last_change: "Dernière modification: %{date}"
   group:
+    festival_tab: Festival
     suisa_tab: SUISA
     merge:
       select:

--- a/config/locales/views.sbv.it.yml
+++ b/config/locales/views.sbv.it.yml
@@ -9,6 +9,7 @@ it:
   global:
     last_change: "Ultima modifica: %{date}"
   group:
+    festival_tab: Festival
     suisa_tab: SUISA
     merge:
       select:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,13 @@ Rails.application.routes.draw do
           post 'submit'
         end
       end
+
+      resources :events, only: [] do
+        collection do
+          get 'festival' => 'events#index', type: 'Event::Festival'
+        end
+      end
+
       resources :song_censuses, only: [:new, :create, :index] do
         post 'remind', to: 'song_censuses#remind'
       end

--- a/lib/hitobito_sbv/wagon.rb
+++ b/lib/hitobito_sbv/wagon.rb
@@ -29,6 +29,7 @@ module HitobitoSbv
 
       ### abilities
       RoleAbility.send :include, Sbv::RoleAbility
+      GroupAbility.send :include, Sbv::GroupAbility
 
       ### controllers
       GroupsController.permitted_attrs += [:vereinssitz, :founding_year,

--- a/spec/abilities/group_ability_spec.rb
+++ b/spec/abilities/group_ability_spec.rb
@@ -11,7 +11,7 @@ require 'spec_helper'
 describe GroupAbility do
 
   subject { ability }
-  let(:role) { Fabricate(Group::Root::Admin.name.to_sym, group: groups(:top_group)) }
+  let(:role) { Fabricate(Group::Root::Admin.name.to_sym, group: groups(:hauptgruppe_1)) }
   let(:ability) { Ability.new(role.person.reload) }
   let(:group) { role.group }
 

--- a/spec/abilities/group_ability_spec.rb
+++ b/spec/abilities/group_ability_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+
+#  Copyright (c) 2012-2019, Jungwacht Blauring Schweiz. This file is part of
+#  hitobito and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito.
+
+require 'spec_helper'
+
+
+describe GroupAbility do
+
+  subject { ability }
+  let(:role) { Fabricate(Group::Root::Admin.name.to_sym, group: groups(:top_group)) }
+  let(:ability) { Ability.new(role.person.reload) }
+  let(:group) { role.group }
+
+  it { is_expected.to be_able_to(:'index_event/festivals', group) }
+end


### PR DESCRIPTION
**Issue:** hitobito/hitobito#881

### Description ###
Adds new event type called `Festival`, which should later support group applications.

### What's changed? ###

- `Event::Festival` is added
- Link to `Festival` is added in (group) Sheet tab navigation
- Group ability is added (for allowing access to festival list/index action)
- Localization files are updated
- Group ability spec is added, although I'm not sure about the value it provides. I couldn't find any examples/similar specs concerning event types

### Screenshots ###

![Festivals](https://user-images.githubusercontent.com/7906832/69792944-d5b82280-11c7-11ea-8e64-960fcfecc507.gif)
