### PR TITLE
Localization of music classification options

### DIFF
--- a/app/helpers/group_participations_helper.rb
+++ b/app/helpers/group_participations_helper.rb
@@ -1,6 +1,8 @@
 module GroupParticipationsHelper
   def music_styles_selection
-    Event::GroupParticipation::MUSIC_CLASSIFICATIONS.map { |h| music_i18n_option(:music_style, h[:style]) }
+    Event::GroupParticipation::MUSIC_CLASSIFICATIONS.map do |h|
+      music_i18n_option(:music_style, h[:style])
+    end
   end
 
   def music_types_selection_for(music_style)
@@ -20,8 +22,9 @@ module GroupParticipationsHelper
   end
 
   def music_i18n_option(kind, value)
+    model_key = Event::GroupParticipation.name.underscore
     [
-      t("activerecord.attributes.#{Event::GroupParticipation.name.underscore}.#{kind.to_s.pluralize}.#{value}"),
+      t("activerecord.attributes.#{model_key}.#{kind.to_s.pluralize}.#{value}"),
       value
     ]
   end

--- a/app/helpers/group_participations_helper.rb
+++ b/app/helpers/group_participations_helper.rb
@@ -1,19 +1,28 @@
 module GroupParticipationsHelper
   def music_styles_selection
-    Event::GroupParticipation::MUSIC_CLASSIFICATIONS.map { |h| h[:style] }
+    Event::GroupParticipation::MUSIC_CLASSIFICATIONS.map { |h| music_i18n_option(:music_style, h[:style]) }
   end
 
   def music_types_selection_for(music_style)
-    music_types_for(music_style).keys
+    music_types_for(music_style).keys.map { |v| music_i18n_option(:music_type, v) }
   end
 
   def music_level_selections_for(music_style)
     music_types_for(music_style).map do |type, levels|
-      content_tag(:div, hidden: true, class: type) { options_for_select(levels || []) }
+      values = levels.map { |level| music_i18n_option(:music_level, level) }
+
+      content_tag(:div, hidden: true, class: type) { options_for_select(values || []) }
     end.join.html_safe
   end
 
   def music_types_for(music_style)
     Event::GroupParticipation::MUSIC_CLASSIFICATIONS.find { |h| h[:style] == music_style }[:types]
+  end
+
+  def music_i18n_option(kind, value)
+    [
+      t("activerecord.attributes.#{Event::GroupParticipation.name.underscore}.#{kind.to_s.pluralize}.#{value}"),
+      value
+    ]
   end
 end

--- a/app/models/event/group_participation.rb
+++ b/app/models/event/group_participation.rb
@@ -7,7 +7,6 @@ require_dependency 'aasm'
 
 class Event::GroupParticipation < ActiveRecord::Base
   include ::AASM
-  include I18nEnums
 
   MUSIC_CLASSIFICATIONS = [
     {
@@ -36,8 +35,6 @@ class Event::GroupParticipation < ActiveRecord::Base
       }
     }
   ].freeze
-
-  # i18n_enum :music_styles, Event::GroupParticipation::MUSIC_CLASSIFICATIONS.map { |h| h[:style] }, key: :music_styles
 
   self.demodulized_route_keys = true
 

--- a/app/views/events/group_participations/edit.html.haml
+++ b/app/views/events/group_participations/edit.html.haml
@@ -4,10 +4,10 @@
 
   - if entry.initial?
     = f.label :music_style
-    = f.select :music_style, music_styles_selection, prompt: 'Select'
+    = f.select :music_style, music_styles_selection, prompt: ''
   - if entry.music_style_selected?
     = f.label :music_type
-    = f.select :music_type, music_types_selection_for(entry.music_style), prompt: 'Select'
+    = f.select :music_type, music_types_selection_for(entry.music_style), prompt: ''
     = f.label :music_level
     = f.select :music_level, []
 


### PR DESCRIPTION
## Issue(s) ##
https://github.com/hitobito/hitobito/issues/883
https://github.com/hitobito/hitobito/issues/885

## Description ##

Currently, we are showing raw values for music class. options, which is not so user-friendly.
Options need to be properly labeled/localized.

## What's changed? ##

- Additional helper method is added for creating localized options (`[label, value]`) in crud form(s)
- Removed remnants of unsuccessful `i18n_enum` implementation
- Removed select field `prompt` values (they were in English anyways)

## Screenshots ##

![Peek 2019-12-30 14-16](https://user-images.githubusercontent.com/7906832/71583881-8b043000-2b10-11ea-9c50-37f17930bcb1.gif)
 