### PR TITLE
Show previosly selected music values

### DIFF
--- a/app/helpers/group_participations_helper.rb
+++ b/app/helpers/group_participations_helper.rb
@@ -20,9 +20,10 @@ module GroupParticipationsHelper
   end
 
   def music_i18n_option(kind, value)
-    [
-      t("activerecord.attributes.#{Event::GroupParticipation.name.underscore}.#{kind.to_s.pluralize}.#{value}"),
-      value
-    ]
+    [ music_i18n(kind, value), value]
+  end
+
+  def music_i18n(kind, value)
+    t("activerecord.attributes.#{Event::GroupParticipation.name.underscore}.#{kind.to_s.pluralize}.#{value}")
   end
 end

--- a/app/views/events/group_participations/edit.html.haml
+++ b/app/views/events/group_participations/edit.html.haml
@@ -1,3 +1,7 @@
+- if entry.music_style_selected?
+  %ul
+    %li #{t(:music_style)}: #{music_i18n(:music_style, entry.music_style)}
+
 = crud_form(path_args(entry),
   cancel_url: polymorphic_path(path_args(model_class), returning: true),
   buttons_bottom: true, buttons_top: false) do |f|


### PR DESCRIPTION
:spiral_notepad: This PR is based out of https://github.com/hitobito/hitobito_sbv/pull/27, so maybe the comparison should be against https://github.com/hitobito/hitobito_sbv/tree/feature/localize-music-prefs-selection branch

:spiral_notepad: This is an implementation suggestion, since there is no specific requirements.

## Description ##

After a conversation with @kronn , it was decided that we should show previously selected values in next step(s) of creating group participations.


## What's changed? ##

- Extract separate (localized) label helper method for music class. choices
- Update `edit` form to show selected `music_style`

## Screenshots##

![Screenshot-1577713684](https://user-images.githubusercontent.com/7906832/71584658-ebe13780-2b13-11ea-8a31-e71db08272ac.png)
