### PR TITLE
Enable preferred playing day selection

### DIFF
--- a/app/helpers/group_participations_helper.rb
+++ b/app/helpers/group_participations_helper.rb
@@ -50,4 +50,18 @@ module GroupParticipationsHelper
     t(:name, event: entry.event.to_s, group: entry.group.to_s,
              scope: 'activerecord.attributes.event/group_participation')
   end
+
+  def play_day_selection_for(record)
+    result = Event::GroupParticipation::MUSIC_LEVEL_PLAY_DAYS
+
+    %i(music_style music_type music_level).each do |attr|
+      break unless result
+
+      result = result[record.public_send(attr)]
+    end
+
+    return [] unless result
+
+    t('date.day_names').values_at(*result)
+  end
 end

--- a/app/models/event/group_participation.rb
+++ b/app/models/event/group_participation.rb
@@ -8,6 +8,11 @@ require_dependency 'aasm'
 class Event::GroupParticipation < ActiveRecord::Base
   include ::AASM
 
+  AVAILABLE_PLAY_DAYS = { thursday: 4, friday: 5, saturday: 6, sunday: 0 }.freeze
+
+  enum preferred_play_day_1: AVAILABLE_PLAY_DAYS, _prefix: :play_day_1
+  enum preferred_play_day_2: AVAILABLE_PLAY_DAYS, _prefix: :play_day_2
+
   MUSIC_CLASSIFICATIONS = [
     {
       style: 'concert_music',
@@ -35,6 +40,54 @@ class Event::GroupParticipation < ActiveRecord::Base
       }
     }
   ].freeze
+
+  MUSIC_LEVEL_PLAY_DAYS = {
+    'concert_music' => {
+      'harmony' => {
+        'highest' => AVAILABLE_PLAY_DAYS.values_at(:friday, :saturday, :sunday),
+        'first'   => AVAILABLE_PLAY_DAYS.values,
+        'second'  => AVAILABLE_PLAY_DAYS.values,
+        'third'   => AVAILABLE_PLAY_DAYS.values,
+        'fourth'  => [AVAILABLE_PLAY_DAYS[:sunday]]
+      },
+      'brass_band' => {
+        'highest' => AVAILABLE_PLAY_DAYS.values_at(:thursday, :friday),
+        'first'   => AVAILABLE_PLAY_DAYS.values,
+        'second'  => AVAILABLE_PLAY_DAYS.values,
+        'third'   => AVAILABLE_PLAY_DAYS.values,
+        'fourth'  => AVAILABLE_PLAY_DAYS.values_at(:thursday)
+      },
+      'fanfare_benelux_harmony' => {
+        'first'  => AVAILABLE_PLAY_DAYS.values_at(:thursday),
+        'second' => AVAILABLE_PLAY_DAYS.values_at(:thursday),
+        'third'  => AVAILABLE_PLAY_DAYS.values_at(:thursday, :friday),
+      },
+      'fanfare_benelux_brass_band' => {
+        'first'  => AVAILABLE_PLAY_DAYS.values_at(:thursday),
+        'second' => AVAILABLE_PLAY_DAYS.values_at(:thursday),
+        'third'  => AVAILABLE_PLAY_DAYS.values_at(:thursday, :friday),
+      },
+      'fanfare_mixte_harmony' => {
+        'fourth' => AVAILABLE_PLAY_DAYS.values_at(:thursday),
+      },
+      'fanfare_mixte_brass_band' => {
+        'fourth' => AVAILABLE_PLAY_DAYS.values_at(:thursday),
+      }
+    },
+    'contemporary_music' => {
+      'harmony' => {
+        'high'   => AVAILABLE_PLAY_DAYS.values_at(:saturday),
+        'medium' => AVAILABLE_PLAY_DAYS.values_at(:saturday, :sunday),
+        'low'    => AVAILABLE_PLAY_DAYS.values_at(:thursday)
+      },
+      'brass_band' => {
+        'high'   => AVAILABLE_PLAY_DAYS.values_at(:sunday),
+        'medium' => AVAILABLE_PLAY_DAYS.values_at(:saturday),
+        'low'    => AVAILABLE_PLAY_DAYS.values_at(:friday)
+      }
+    },
+    'parade_music' => {}
+  }.freeze
 
   self.demodulized_route_keys = true
 
@@ -70,6 +123,10 @@ class Event::GroupParticipation < ActiveRecord::Base
 
     event :select_music_type do
       transitions from: :music_style_selected,          to: :music_type_and_level_selected
+    end
+
+    event :select_preferred_play_day do
+      transitions from: :music_type_and_level_selected, to: :preferred_play_day_selected
     end
   end
 

--- a/app/views/events/group_participations/edit.html.haml
+++ b/app/views/events/group_participations/edit.html.haml
@@ -15,5 +15,11 @@
     = f.label :music_level
     = f.select :music_level, []
 
+  - if entry.music_type_and_level_selected?
+    = f.label :preferred_play_day_1
+    = f.select :preferred_play_day_1, play_day_selection_for(entry), prompt: ''
+    = f.label :preferred_play_day_2
+    = f.select :preferred_play_day_2, play_day_selection_for(entry), prompt: ''
+
 = music_level_selections_for(entry.music_style) if entry.music_style_selected?
 

--- a/config/initializers/ar_5_enum.rb
+++ b/config/initializers/ar_5_enum.rb
@@ -1,0 +1,77 @@
+# https://gist.github.com/deecewan/6baa54bc7253ba61f44258b301027cb9
+
+module ActiveRecord
+    module Enum
+      def enum(definitions)
+        klass = self
+        enum_prefix = definitions.delete(:_prefix)
+        enum_suffix = definitions.delete(:_suffix)
+        definitions.each do |name, values|
+          # statuses = { }
+          enum_values = ActiveSupport::HashWithIndifferentAccess.new
+          name        = name.to_sym
+
+          # def self.statuses() statuses end
+          detect_enum_conflict!(name, name.to_s.pluralize, true)
+          klass.singleton_class.send(:define_method, name.to_s.pluralize) { enum_values }
+
+          _enum_methods_module.module_eval do
+            # BEGIN from Rails 4 http://apidock.com/rails/v4.2.7/ActiveRecord/Enum/enum
+            # def status=(value) self[:status] = statuses[value] end
+            klass.send(:detect_enum_conflict!, name, "#{name}=")
+            define_method("#{name}=") { |value|
+              if enum_values.has_key?(value) || value.blank?
+                self[name] = enum_values[value]
+              elsif enum_values.has_value?(value)
+                # Assigning a value directly is not a end-user feature, hence it's not documented.
+                # This is used internally to make building objects from the generated scopes work
+                # as expected, i.e. +Conversation.archived.build.archived?+ should be true.
+                self[name] = value
+              else
+                raise ArgumentError, "'#{value}' is not a valid #{name}"
+              end
+            }
+
+            # def status() statuses.key self[:status] end
+            klass.send(:detect_enum_conflict!, name, name)
+            define_method(name) { enum_values.key self[name] }
+
+            # def status_before_type_cast() statuses.key self[:status] end
+            klass.send(:detect_enum_conflict!, name, "#{name}_before_type_cast")
+            define_method("#{name}_before_type_cast") { enum_values.key self[name] }
+            # END from Rails 4 http://apidock.com/rails/v4.2.7/ActiveRecord/Enum/enum
+
+            pairs = values.respond_to?(:each_pair) ? values.each_pair : values.each_with_index
+            pairs.each do |value, i|
+              if enum_prefix == true
+                prefix = "#{name}_"
+              elsif enum_prefix
+                prefix = "#{enum_prefix}_"
+              end
+              if enum_suffix == true
+                suffix = "_#{name}"
+              elsif enum_suffix
+                suffix = "_#{enum_suffix}"
+              end
+
+              value_method_name = "#{prefix}#{value}#{suffix}"
+              enum_values[value] = i
+
+              # def active?() status == 0 end
+              klass.send(:detect_enum_conflict!, name, "#{value_method_name}?")
+              define_method("#{value_method_name}?") { self[name] == i }
+
+              # def active!() update! status: :active end
+              klass.send(:detect_enum_conflict!, name, "#{value_method_name}!")
+              define_method("#{value_method_name}!") { update! name => value }
+
+              # scope :active, -> { where status: 0 }
+              klass.send(:detect_enum_conflict!, name, value_method_name, true)
+              klass.scope value_method_name, -> { klass.where name => i }
+            end
+          end
+          defined_enums[name.to_s] = enum_values
+        end
+      end
+    end
+  end

--- a/db/migrate/20191231135200_add_preferred_play_days_on_group_participations.rb
+++ b/db/migrate/20191231135200_add_preferred_play_days_on_group_participations.rb
@@ -1,6 +1,6 @@
 class AddPreferredPlayDaysOnGroupParticipations < ActiveRecord::Migration
   def change
-    # add_column :event_group_participations, :preferred_play_day_1, :integer
-    # add_column :event_group_participations, :preferred_play_day_2, :integer
+    add_column :event_group_participations, :preferred_play_day_1, :integer
+    add_column :event_group_participations, :preferred_play_day_2, :integer
   end
 end

--- a/db/migrate/20191231135200_add_preferred_play_days_on_group_participations.rb
+++ b/db/migrate/20191231135200_add_preferred_play_days_on_group_participations.rb
@@ -1,0 +1,6 @@
+class AddPreferredPlayDaysOnGroupParticipations < ActiveRecord::Migration
+  def change
+    # add_column :event_group_participations, :preferred_play_day_1, :integer
+    # add_column :event_group_participations, :preferred_play_day_2, :integer
+  end
+end


### PR DESCRIPTION
## Issue ##
https://github.com/hitobito/hitobito/issues/886

## Description ##

When creating group participation, group can select on which (available) would they **like** to perform.

## What's changed? ##

- Two columns are added to group participation (`preferred_play_day_1, preferred_play_day_2`)
- `AR::Enum` has been patched to mimic AR 5 behavior (`_prefix` option is needed in order to have two enum fields with same potential values)
- Constant/Registry of available play days per music style, type and level is added
- Added helper function for localization of weekdays available for selection

## What's missing? ##

- Day that is selected in `preferred_play_day_1` should be disabled in `preferred_play_day_2` select field
- `preferred_play_day_` fields should be properly localized

## What should/can be improved? ##

`AR::Enum` monkey patch seems like an overkill. We should really revise the decision for making those columns enums. As I see it, currently, only integer values would suffice, since the actual day names can be fetched like [THIS](https://github.com/hitobito/hitobito_sbv/blob/feature/enable-selecting-date-preference/app/helpers/group_participations_helper.rb#L65)

----

`MUSIC_LEVEL_PLAY_DAYS` contains a lot of duplication from `MUSIC_CLASSIFICATION`. Maybe we should consider merging them

## Screenshots ##

![Peek 2019-12-31 16-02](https://user-images.githubusercontent.com/7906832/71625579-e30e6580-2be8-11ea-9b33-7447aef3373c.gif)


