### PR TITLE
Leere SUISA-Meldungen

### DIFF
--- a/app/abilities/song_ability.rb
+++ b/app/abilities/song_ability.rb
@@ -21,6 +21,7 @@ class SongAbility < AbilityDsl::Base
     permission(:song_census).may(:manage).in_dachverband
     permission(:song_census).may(:manage).in_verein
     permission(:song_census).may(:submit).in_verein
+    permission(:song_census).may(:create).in_verein
     permission(:layer_and_below_read).may(:read).in_verein
   end
 

--- a/app/controllers/concerts_controller.rb
+++ b/app/controllers/concerts_controller.rb
@@ -51,7 +51,7 @@ class ConcertsController < SimpleCrudController
   end
 
   def list_entries
-    list = super.includes(song_counts: :song).includes(:song_census).in(year).without_deleted
+    list = super.includes(song_counts: :song).includes(:song_census).in(year)
 
     if list.present? && list.any?(&:played?)
       list.where(reason: nil)

--- a/app/controllers/concerts_controller.rb
+++ b/app/controllers/concerts_controller.rb
@@ -30,16 +30,14 @@ class ConcertsController < SimpleCrudController
   end
 
   def submit
-    submitted = with_callbacks(:create, :save) do
-      CensusSubmission.new(parent, census).submit
-    end
+    submitted = CensusSubmission.new(parent, census).submit
     respond_with(parent, success: submitted, location: group_concerts_path(parent))
   end
 
   private
 
   def remove_existing_unplayed_concerts
-    (entry.verein.concerts.not_played - [entry]).each(&:really_destroy)
+    (entry.verein.concerts.not_played - [entry]).each(&:really_destroy!)
   end
 
   def assign_attributes

--- a/app/controllers/concerts_controller.rb
+++ b/app/controllers/concerts_controller.rb
@@ -30,7 +30,9 @@ class ConcertsController < SimpleCrudController
   end
 
   def submit
-    submitted = CensusSubmission.new(parent, census).submit
+    submitted = with_callbacks(:save) do
+      CensusSubmission.new(parent, census).submit
+    end
     respond_with(parent, success: submitted, location: group_concerts_path(parent))
   end
 

--- a/app/controllers/concerts_controller.rb
+++ b/app/controllers/concerts_controller.rb
@@ -21,6 +21,8 @@ class ConcertsController < SimpleCrudController
 
   helper_method :census
 
+  after_create :remove_existing_unplayed_concerts
+
   def new
     entry.song_counts = parent.last_played_song_ids.map do |id|
       SongCount.new(song_id: id, count: 0)
@@ -35,6 +37,10 @@ class ConcertsController < SimpleCrudController
   end
 
   private
+
+  def remove_existing_unplayed_concerts
+    (entry.verein.concerts.not_played - [entry]).each(&:really_destroy)
+  end
 
   def assign_attributes
     super

--- a/app/controllers/concerts_controller.rb
+++ b/app/controllers/concerts_controller.rb
@@ -9,8 +9,7 @@ class ConcertsController < SimpleCrudController
   include YearBasedPaging
 
   self.nesting = Group
-  self.permitted_attrs = [:name, :performed_at, :year, :verein_id, :song_census_id,
-                          :reason,
+  self.permitted_attrs = [:name, :performed_at, :year, :verein_id, :song_census_id, :reason,
                           song_counts_attributes: [
                             :id,
                             :count,
@@ -53,13 +52,7 @@ class ConcertsController < SimpleCrudController
   end
 
   def list_entries
-    list = super.includes(song_counts: :song).includes(:song_census).in(year)
-
-    if list.present? && list.any?(&:played?)
-      list.where(reason: nil)
-    else
-      list
-    end
+    super.includes(song_counts: :song).includes(:song_census).in(year)
   end
 
   def census

--- a/app/domain/census_calculator.rb
+++ b/app/domain/census_calculator.rb
@@ -32,7 +32,7 @@ class CensusCalculator
       .each_with_object({}) do |(verein, reason), memo|
         next if memo[verein].present? # any reason
 
-        memo[verein] = reason || 'played'
+        memo[verein] = reason || 'submitted' # coupling with view/i18n
       end
   end
 

--- a/app/domain/census_submission.rb
+++ b/app/domain/census_submission.rb
@@ -14,7 +14,7 @@ class CensusSubmission
 
   def submit
     changed_rows = attach_concerts_to_census
-    changed_rows > 0
+    changed_rows.positive?
   end
 
   private

--- a/app/models/concert.rb
+++ b/app/models/concert.rb
@@ -25,7 +25,6 @@
 class Concert < ActiveRecord::Base
 
   acts_as_paranoid
-  extend Paranoia::RegularScope
 
   belongs_to :song_census
   belongs_to :verein, class_name: 'Group::Verein'

--- a/app/models/concert.rb
+++ b/app/models/concert.rb
@@ -46,11 +46,19 @@ class Concert < ActiveRecord::Base
 
   accepts_nested_attributes_for :song_counts, allow_destroy: true
 
+  include I18nEnums
+  REASONS = %w(joint_play not_playable otherwise_billed).freeze
+  i18n_enum :reason, REASONS, scopes: true, queries: true
+
   scope :in, ->(year) { where(year: year) }
   default_scope { order(performed_at: :desc) }
 
   def to_s
     name
+  end
+
+  def played?
+    self[:reason].nil?
   end
 
   private

--- a/app/models/concert.rb
+++ b/app/models/concert.rb
@@ -51,6 +51,9 @@ class Concert < ActiveRecord::Base
   i18n_enum :reason, REASONS, scopes: true, queries: true
 
   scope :in, ->(year) { where(year: year) }
+  scope :not_played, -> { where.not(reason: nil) }
+  scope :played, -> { where(reason: nil) }
+
   default_scope { order(performed_at: :desc) }
 
   def to_s

--- a/app/views/concerts/index.html.haml
+++ b/app/views/concerts/index.html.haml
@@ -4,5 +4,22 @@
 = render 'shared/page_per_year'
 
 #main.row-fluid.song-counts
-  .list
-    = render 'list', list: @list
+  - if entries.blank?
+    = form_for([@group, Concert.new], method: :post, class: 'no-concerts') do |f|
+      %p
+        = t('.no_concerts_yet')
+      - Concert.reason_labels.each do |reason, desc|
+        %p
+          = f.label(:"reason_#{reason}", class: 'radio') do
+            = f.radio_button(:reason, reason)
+            = desc
+
+      = f.hidden_field :verein_id, value: @group.id
+      = f.hidden_field :year, value: year
+      = f.hidden_field :performed_at, value: Date.current
+      %p
+        = button_tag(ti('button.save'), class: 'btn btn-primary', data: { disable_with: ti('button.save') })
+
+  - else
+    .list
+      = render 'list'

--- a/app/views/song_censuses/_totals.html.haml
+++ b/app/views/song_censuses/_totals.html.haml
@@ -31,4 +31,4 @@
     - t.col do |verein|
       = link_to(verein.name, group_song_censuses_path(verein, year: year))
     - t.col do |verein|
-      = t(@total[:verein][verein.id] ? '.submitted': '.not_submitted')
+      = t(".#{@total[:verein][verein.id].presence || 'not_submitted'}")

--- a/bin/rails
+++ b/bin/rails
@@ -1,6 +1,13 @@
 #!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
 
-APP_PATH = File.expand_path('../../config/application',  __FILE__)
-require File.expand_path('../../config/boot',  __FILE__)
-require_relative 'commands'
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/hitobito_sbv', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails/all"
+require "rails/engine/commands"

--- a/config/locales/models.sbv.de.yml
+++ b/config/locales/models.sbv.de.yml
@@ -331,6 +331,11 @@ de:
         song_counts: Werkeintrag
         performed_at: Datum
         name: Aufführung
+        reasons:
+          _nil: gespielt
+          joint_play: Spielgemeinschaft
+          not_playable: nicht spielfähig in diesem Jahr
+          otherwise_billed: SUISA über Dritte abgerechnet
 
       event/group_participation:
         name: "Gruppenanmeldung bei %{event} als %{group}"

--- a/config/locales/views.sbv.de.yml
+++ b/config/locales/views.sbv.de.yml
@@ -33,6 +33,9 @@ de:
       submitted: eingereicht
       not_submitted: nicht eingereicht
       censuses_submitted: "%{submitted} von %{total} eingereicht"
+      joint_play: Spielgemeinschaft
+      not_playable: nicht spielfähig in diesem Jahr
+      otherwise_billed: SUISA über Dritte abgerechnet
     verein:
       search: Werk suchen…
     submit: Meldeliste einreichen

--- a/config/locales/views.sbv.de.yml
+++ b/config/locales/views.sbv.de.yml
@@ -117,6 +117,8 @@ de:
     csv: CSV
     xlsx: Excel
   concerts:
+    index:
+      no_concerts_yet: "Um die SUISA-Meldeliste einzureichen müssen Sie mindestens eine Aufführung hinzufügen oder eine alternative Erledigung wählen:"
     submit:
       flash:
         success: Meldeliste eingereicht.

--- a/db/migrate/20190617114700_migrate_to_superstructure.rb
+++ b/db/migrate/20190617114700_migrate_to_superstructure.rb
@@ -61,10 +61,12 @@ class MigrateToSuperstructure < ActiveRecord::Migration[4.2]
       Group.rebuild!(false)
     end
 
-    say_with_time 'Relink concerts to verbandsebenen' do
-      Concert.find_each do |concert|
-        concert.send(:set_verband_ids)
-        concert.save if concert.changes.any?
+    unless Rails.env.test? # this breaks with the addition of paranoia to the concerts
+      say_with_time 'Relink concerts to verbandsebenen' do
+        Concert.find_each do |concert|
+          concert.send(:set_verband_ids)
+          concert.save if concert.changes.any?
+        end
       end
     end
   end
@@ -131,10 +133,12 @@ class MigrateToSuperstructure < ActiveRecord::Migration[4.2]
       Group.rebuild!(false)
     end
 
-    say_with_time 'Relink concerts to verbandsebenen' do
-      Concert.find_each do |concert|
-        concert.send(:set_verband_ids)
-        concert.save if concert.changes.any?
+    unless Rails.env.test? # this breaks with the addition of paranoia to the concerts
+      say_with_time 'Relink concerts to verbandsebenen' do
+        Concert.find_each do |concert|
+          concert.send(:set_verband_ids)
+          concert.save if concert.changes.any?
+        end
       end
     end
   end

--- a/db/migrate/20200828121113_add_reason_to_concerts.rb
+++ b/db/migrate/20200828121113_add_reason_to_concerts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2020, Schweizer Blasmusikverband. This file is part of
+#  hitobito_sbv and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sbv.
+
+class AddReasonToConcerts < ActiveRecord::Migration[6.0]
+  def change
+    add_column :concerts, :reason, :string
+  end
+end

--- a/lib/hitobito_sbv.rb
+++ b/lib/hitobito_sbv.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 #  Copyright (c) 2012-2018, Schweizer Blasmusikverband. This file is part of

--- a/spec/fixtures/concerts.yml
+++ b/spec/fixtures/concerts.yml
@@ -54,3 +54,10 @@ six_concert:
   verein: musikverband_hastdutoene
   year: 2018
   song_census:
+
+unplayed_concert:
+  name: not playable this year
+  verein: musikverband_alterswil
+  year: 2019
+  song_census: two_o_19
+  reason: not_playable

--- a/spec/models/concert_spec.rb
+++ b/spec/models/concert_spec.rb
@@ -85,4 +85,56 @@ describe Concert do
       end.to change { Concert.without_deleted.count }.by(-1)
     end
   end
+
+  context 'reason' do
+    subject(:concert) { concerts(:six_concert) }
+
+    it 'can be joint_play' do
+      concert.reason = 'joint_play'
+
+      is_expected.to be_joint_play
+      expect(concert.reason).to eq 'joint_play'
+      expect(concert.reason_label).to eq reason('joint_play')
+
+      is_expected.to be_valid
+    end
+
+    it 'can be not_playable' do
+      concert.reason = 'not_playable'
+
+      is_expected.to be_not_playable
+      expect(concert.reason).to eq 'not_playable'
+      expect(concert.reason_label).to eq reason('not_playable')
+
+      is_expected.to be_valid
+    end
+
+    it 'can be otherwise_billed' do
+      concert.reason = 'otherwise_billed'
+
+      is_expected.to be_otherwise_billed
+      expect(concert.reason).to eq 'otherwise_billed'
+      expect(concert.reason_label).to eq reason('otherwise_billed')
+
+      is_expected.to be_valid
+    end
+
+    it 'cannot be something else' do
+      expect do
+        concert.reason = 'something else'
+      end.to change(concert, :valid?).from(true).to(false)
+    end
+
+    it 'is played by default' do
+      new_concert = described_class.new
+
+      expect(new_concert).to be_played
+      expect(new_concert.reason).to be_nil
+      expect(new_concert.reason_label).to eq reason('_nil')
+    end
+
+    def reason(key)
+      I18n.t(key, scope: "activerecord.attributes.concert.reasons")
+    end
+  end
 end

--- a/spec/models/concert_spec.rb
+++ b/spec/models/concert_spec.rb
@@ -133,6 +133,18 @@ describe Concert do
       expect(new_concert.reason_label).to eq reason('_nil')
     end
 
+    context 'comes with scopes' do # whose concrete results depend on fixtures. sorry.
+      it 'to select played/normale concerts' do
+        expect(described_class).to respond_to(:played)
+        expect(described_class.played.count).to be 6
+      end
+
+      it 'to select not played/placeholder concerts' do
+        expect(described_class).to respond_to(:not_played)
+        expect(described_class.not_played.count).to be 1
+      end
+    end
+
     def reason(key)
       I18n.t(key, scope: "activerecord.attributes.concert.reasons")
     end


### PR DESCRIPTION
Fixes #49 

Nicht implementiert sind:

- Icons vor dem Status (Kann separat gemacht werden)
- spezielles Styling der "leeren Liste" (Hier sollte vielleicht ein allgemeines Design für diesen Fall gefunden werden)
- Export-Erweiterung (der Export listet die gespielten Stücke auf, Leermeldungen passen da nicht so leicht rein)
