### PR TITLE
Fix moving groups in specific conditions

### DIFF
--- a/app/models/sbv/group/nested_set.rb
+++ b/app/models/sbv/group/nested_set.rb
@@ -1,29 +1,46 @@
 # frozen_string_literal: true
 
-#  Copyright (c) 2019, Schweizer Blasmusikverband. This file is part of
+#  Copyright (c) 2019-2023, Schweizer Blasmusikverband. This file is part of
 #  hitobito_sbv and licensed under the Affero General Public License version 3
 #  or later. See the COPYING file at the top-level directory or at
 #  https://github.com/hitobito/hitobito_sbv.
 
 module Sbv
   module Group::NestedSet
-    private
+    extend ActiveSupport::Concern
 
-    # rubocop:disable Style/IfInsideElse,Style/RedundantSelf,Rails/FindEach
-    # copied from awesome_nested_set to accomodate for a little change
-    def find_left_neighbor(parent, order_attribute, ascending)
-      left = nil
-
-      # change from upsteam version to omit secondary and tertiary children
-      parent.children.where(parent_id: parent.id).each do |n|
-        if ascending
-          left = n if n.send(order_attribute) < self.send(order_attribute)
-        else
-          left = n if n.send(order_attribute) > self.send(order_attribute)
-        end
+    included do
+      def direct_children_of(group)
+        group.children.where(parent_id: group.id)
       end
-      left
+
+      # rubocop:disable Style/IfInsideElse,Style/RedundantSelf,Rails/FindEach
+      # copied from awesome_nested_set to accomodate for a little change
+      def find_left_neighbor(parent, order_attribute, ascending)
+        left = nil
+
+        # change from upsteam version to omit secondary and tertiary children
+        direct_children_of(parent).each do |n|
+          if ascending
+            left = n if n.send(order_attribute) < self.send(order_attribute)
+          else
+            left = n if n.send(order_attribute) > self.send(order_attribute)
+          end
+        end
+        left
+      end
+      # rubocop:enable Style/IfInsideElse,Style/RedundantSelf,Rails/FindEach
     end
-    # rubocop:enable Style/IfInsideElse,Style/RedundantSelf,Rails/FindEach
+
+    def move_required?
+      (@move_to_new_parent_id != false || @move_to_new_name != false) &&
+        parent_id &&
+        direct_children_of(parent).count > 1
+    end
+
+    def move_to_most_left_if_change
+      first = direct_children_of(parent).first
+      move_to_left_of(first) unless first == self
+    end
   end
 end

--- a/spec/domain/group/mover_spec.rb
+++ b/spec/domain/group/mover_spec.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+
+#  Copyright (c) 2023, Schweizer Blasmusikverband. This file is part of
+#  hitobito_sbv and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sbv.
+
+require 'spec_helper'
+describe Group::Mover do
+
+  let(:move) { Group::Mover.new(group) }
+
+  context 'moving a Verein to a different Regionalverband in the same Mitgliederverband' do
+    let(:group) { groups(:musikgesellschaft_aarberg) }
+    let(:target) { Fabricate(Group::Regionalverband.name) }
+
+    context 'moves group' do
+      subject { group.reload }
+      before { move.perform(target) }
+
+      its(:parent) { is_expected.to eq target }
+      its(:layer_group_id) { is_expected.to eq group.id }
+
+      it 'nested set should still be valid' do
+        expect(Group).to be_valid
+      end
+
+      it 'keeps layer group id of Verein children' do
+        expect(groups(:vorstand_mg_aarberg).layer_group_id).to eq(group.id)
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes hitobito/hitobito#736
Fixes https://help.puzzle.ch/#ticket/zoom/5707

Die SBV-spezifischen Anpassungen mit sekundärer und weiterer Gruppenzugehörigkeit von Gruppen hat sich beim Gruppen Verschieben in sehr spezifischen Umständen ausgewirkt. Dieser PR ergänzt daher die nötigen SBV-spezifischen Anpassungen an der Logik die beim Gruppen Verschieben läuft.