### PR TITLE
Feld Vereinssitz auf Infoseite und in CSV Untergruppen (#81)

### DIFF
--- a/app/domain/export/tabular/groups/address_list.rb
+++ b/app/domain/export/tabular/groups/address_list.rb
@@ -15,7 +15,7 @@ module Export::Tabular::Groups
         secondary_parent tertiary_parent
         email contact contact_email address_care_of address postbox zip_code town country
         besetzung klasse unterhaltungsmusik
-        language subventionen founding_year recognized_members
+        language subventionen vereinssitz founding_year recognized_members
         suisa_status
       ]
     end

--- a/app/models/group/verein.rb
+++ b/app/models/group/verein.rb
@@ -59,7 +59,8 @@ class Group::Verein < ::Group
     Group::VereinArbeitsgruppe,
     Group::VereinKontakte
 
-  self.used_attributes += [:founding_year,
+  self.used_attributes += [:vereinssitz,
+    :founding_year,
     :besetzung,
     :klasse,
     :unterhaltungsmusik,

--- a/spec/jobs/export/subgroups_export_job_spec.rb
+++ b/spec/jobs/export/subgroups_export_job_spec.rb
@@ -46,6 +46,7 @@ describe Export::SubgroupsExportJob do
       "Unterhaltungsmusik",
       "Korrespondenzsprache",
       "Subventionen",
+      "Vereinssitz",
       "Gründungsjahr",
       "Erfasste Mitglieder",
       "SUISA Status"


### PR DESCRIPTION
## Summary
- Zeigt das Gruppenattribut `vereinssitz` auf der Vereins-Infoseite vor dem Gründungsjahr an.
- Ergänzt die Spalte «Vereinssitz» im Export «CSV Untergruppen» direkt vor «Gründungsjahr».

Closes #81

## Test plan
- [ ] Verein mit gesetztem Vereinssitz öffnen: Infoseite zeigt «Vereinssitz» vor «Gründungsjahr».
- [ ] Export «CSV Untergruppen» ausführen: Spalte «Vereinssitz» ist vorhanden und enthält den erwarteten Wert.
- [ ] `bundle exec rspec spec/jobs/export/subgroups_export_job_spec.rb`


Made with [Cursor](https://cursor.com)