### PR TITLE
Name export jobs distinctly in job overview

### DIFF
--- a/app/controllers/song_counts_controller.rb
+++ b/app/controllers/song_counts_controller.rb
@@ -7,7 +7,7 @@
 
 class SongCountsController < SimpleCrudController
   include YearBasedPaging
-  include UserManageableExportJob
+  include ExportableRedirect
 
   self.nesting = Group
   self.permitted_attrs = [:song_id, :year, :count]
@@ -42,7 +42,7 @@ class SongCountsController < SimpleCrudController
       parent.id,
       year,
       filename: export_filename(format)).enqueue!
-    respond_to_export_job(redirection_target: target)
+    redirect_after_enqueued_export(target)
   end
 
   def export_filename(_format)

--- a/app/controllers/song_counts_controller.rb
+++ b/app/controllers/song_counts_controller.rb
@@ -7,7 +7,7 @@
 
 class SongCountsController < SimpleCrudController
   include YearBasedPaging
-  include AsyncDownload
+  include UserManageableExportJob
 
   self.nesting = Group
   self.permitted_attrs = [:song_id, :year, :count]
@@ -37,14 +37,12 @@ class SongCountsController < SimpleCrudController
 
   def render_tabular_in_background(format)
     target = verein? ? group_concerts_path(@group) : group_song_censuses_path(@group)
-    with_async_download_cookie(format, export_filename(format),
-      redirection_target: target) do |filename|
-      Export::SongCountsExportJob.new(format,
-        current_person.id,
-        parent.id,
-        year,
-        filename: filename).enqueue!
-    end
+    Export::SongCountsExportJob.new(format,
+      current_person.id,
+      parent.id,
+      year,
+      filename: export_filename(format)).enqueue!
+    respond_to_export_job(redirection_target: target)
   end
 
   def export_filename(_format)

--- a/app/jobs/sbv/export/labels_job.rb
+++ b/app/jobs/sbv/export/labels_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Blasmusikverband. This file is part of
+#  hitobito_sbv and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sbv.
+
+module Sbv::Export::LabelsJob
+  PDF_ADDRESS_LIST_JOB_CLASS = "Export::PdfAddressListJob"
+
+  def enqueue!(options = {})
+    delayed_job = super
+    rename_job_observation_for_pdf_address_list!
+    delayed_job
+  end
+
+  private
+
+  def pdf_address_list_export?
+    @format == :pdf && @options[:label_format_id].blank?
+  end
+
+  def rename_job_observation_for_pdf_address_list!
+    return unless pdf_address_list_export?
+    return unless defined?(@job_observation_id) && @job_observation_id
+
+    job_observation.update!(job_class: PDF_ADDRESS_LIST_JOB_CLASS)
+  end
+end

--- a/config/locales/models.sbv.de.yml
+++ b/config/locales/models.sbv.de.yml
@@ -388,4 +388,5 @@ de:
       cannot_be_later_than_end_on: muss vor oder am selben Tag wie der Austritt sein
 
   delayed_job:
+    export/pdf_address_list_job: PDF-Adressliste
     export/song_counts_export_job: Werkmeldungs-Export

--- a/config/locales/models.sbv.de.yml
+++ b/config/locales/models.sbv.de.yml
@@ -386,3 +386,6 @@ de:
     messages:
       cannot_be_later_than_today: kann nicht später als heute sein
       cannot_be_later_than_end_on: muss vor oder am selben Tag wie der Austritt sein
+
+  delayed_job:
+    export/song_counts_export_job: Werkmeldungs-Export

--- a/config/locales/models.sbv.fr.yml
+++ b/config/locales/models.sbv.fr.yml
@@ -458,3 +458,7 @@ fr:
     messages:
       cannot_be_later_than_today: ne peut pas être postérieur à aujourd'hui
       cannot_be_later_than_end_on: doit être avant ou au même jour que la sortie
+
+  delayed_job:
+    export/pdf_address_list_job: Liste PDF adresses
+    export/song_counts_export_job: Werkmeldungs-Export

--- a/config/locales/models.sbv.it.yml
+++ b/config/locales/models.sbv.it.yml
@@ -445,3 +445,7 @@ it:
     messages:
       cannot_be_later_than_today: non può essere più tardi di oggi
       cannot_be_later_than_end_on: muss vor oder am selben Tag wie der Austritt sein
+
+  delayed_job:
+    export/pdf_address_list_job: Elenco PDF indirizzi
+    export/song_counts_export_job: Werkmeldungs-Export

--- a/config/locales/views.sbv.de.yml
+++ b/config/locales/views.sbv.de.yml
@@ -103,7 +103,7 @@ de:
         (Gruppen, Anlässe und Listen; keine anderen Personen) sehen.
 
   song_counts:
-    export_enqueued: 'Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen.'
+    export_enqueued: "Export wird im Hintergrund gestartet und kann nach Fertigstellung auf der Jobübersicht heruntergeladen werden: %{overview_link}"
 
   subscriber:
       group:

--- a/lib/hitobito_sbv/wagon.rb
+++ b/lib/hitobito_sbv/wagon.rb
@@ -74,6 +74,7 @@ module HitobitoSbv
       Sheet::Group.include Sbv::Sheet::Group
 
       ### jobs
+      Export::LabelsJob.prepend Sbv::Export::LabelsJob
       Export::SubgroupsExportJob.prepend Sbv::Export::SubgroupsExportJob
 
       ### mailers

--- a/spec/controllers/song_counts_controller_spec.rb
+++ b/spec/controllers/song_counts_controller_spec.rb
@@ -20,17 +20,17 @@ describe SongCountsController do
 
     it "exports csv" do
       get :index, params: {group_id: verein}, format: :csv
-      # rubocop:todo Layout/LineLength
-      expect(flash[:notice]).to eq "Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen."
-      # rubocop:enable Layout/LineLength
+      expect(flash[:notice]).to match(
+        /Export wird im Hintergrund gestartet und kann nach Fertigstellung auf der Jobübersicht/
+      )
       expect(response).to redirect_to group_concerts_path(verein)
     end
 
     it "exports xlsx" do
       get :index, params: {group_id: group}, format: :xlsx
-      # rubocop:todo Layout/LineLength
-      expect(flash[:notice]).to eq "Export wird im Hintergrund gestartet und nach Fertigstellung heruntergeladen."
-      # rubocop:enable Layout/LineLength
+      expect(flash[:notice]).to match(
+        /Export wird im Hintergrund gestartet und kann nach Fertigstellung auf der Jobübersicht/
+      )
       expect(response).to redirect_to group_song_censuses_path(group)
     end
   end

--- a/spec/jobs/export/labels_job_spec.rb
+++ b/spec/jobs/export/labels_job_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+#  Copyright (c) 2026, Schweizer Blasmusikverband. This file is part of
+#  hitobito_sbv and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_sbv.
+
+require "spec_helper"
+
+if defined?(JobObservation)
+  describe Export::LabelsJob do
+    let(:user) { people(:admin) }
+    let(:group) { groups(:musikverband_hastdutoene) }
+    let(:person) { people(:member) }
+    let(:filename) { AsyncDownloadFile.create_name("people_export", user.id) }
+
+    subject do
+      Export::LabelsJob.new(
+        :pdf,
+        user.id,
+        [person.id],
+        group.id,
+        filename: filename
+      )
+    end
+
+    it "registers pdf address list exports under a dedicated job name" do
+      subject.enqueue!
+      observation = JobObservation.order(id: :desc).first
+
+      expect(observation.job_class).to eq Sbv::Export::LabelsJob::PDF_ADDRESS_LIST_JOB_CLASS
+      expect(observation.job_name).to eq "PDF-Adressliste"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Register PDF people list exports (without label format) under `Export::PdfAddressListJob` instead of `Export::LabelsJob`, so they no longer appear as «Etiketten-Export» in the job overview.
- Add German, French, and Italian translations for the new job name («PDF-Adressliste»).
- Builds on the job overview work from `feature/4020-ui-for-background-jobs` (song count export naming and redirect). Further export job names can follow on this branch.

## Test plan
- [ ] Start a PDF export from the people list (without selecting a label format).
- [ ] Open the job overview and verify the job is listed as «PDF-Adressliste», not «Etiketten-Export».
- [ ] Start an Etiketten PDF export (with label format) and verify it still shows as «Etiketten-Export».
- [ ] Run `spec/jobs/export/labels_job_spec.rb` with a Hitobito version that includes `JobObservation`.


Made with [Cursor](https://cursor.com)